### PR TITLE
Fix, button appears glitched in mobile

### DIFF
--- a/src/components/ButtonV2/index.tsx
+++ b/src/components/ButtonV2/index.tsx
@@ -1,15 +1,18 @@
 import styled, { css } from "styled-components";
 
-export const ButtonV2 = styled.a`
+export const ButtonV2 = styled.button`
     padding: 11px 32px;
     border-radius: 100px;
     text-align: center;
-
+    display: block;
+    border: 0;
+    outline: 0;
+    
     ${({ color, background, w, h }: { color?: string; background?: string; w?: number; h?: number }) => css`
         color: ${color || "white"};
         background: ${background || "black"};
         width: ${w || "null"}px;
-        height: ${h || "40"}px;
+        height: ${`${h}px` || "auto"};
         font-weight: 600;
         font-size: 15px;
         line-height: 18px;


### PR DESCRIPTION
## Motivation
Some buttons appear glithed in mobile.

![imagen](https://user-images.githubusercontent.com/38158676/89462402-a05bcf80-d76d-11ea-892c-7f00a4758433.png)

## Possible reason
There is a warning which says
```
Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
```
ButtonV2 component is an anchor element so it's not recommended to be used inside another <a>. Anyway it allows you to do it, but then there is the glitch.

A quick fix would be to apply `display: block` to ButtonV2 component but there is still the warning.

## Fix
Convert ButtonV2 into a button and make the height auto instead of fixed since the text inside will break the line in mobile.

* They now look fine
* No more warning

## Result
Note: the desktop version looks the same 👍 

Mobile now:

![imagen](https://user-images.githubusercontent.com/38158676/89462940-75be4680-d76e-11ea-89ed-74ff30e6e19b.png)

