### PR TITLE
Update links and improve development documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,18 @@ _Have an idea for our website? You can drop a suggestion in our [Discord server]
     Once all the dependencies have installed without errors, run the following commands in your terminal.
 
     ```shell
-    yarn develop
+    # Developing the frontend
+    yarn develop:web
+
+    # Developing the api
+    yarn develop:api
     ```
 
 1.  **Start hacking**
 
     You should see a message in the terminal like this:
 
-    ```shell
+    ```
     You can now view dothq.co in the browser.
     ⠀
       http://localhost:8000/

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ _Have an idea for our website? You can drop a suggestion in our [Discord server]
     The site is now running and you can visit in your browser of choice *(hopefully [Dot Browser](https://github.com/dothq/browser))* at `localhost:8000/`. If the port is different in the above message, you can substitute `:8000` for what it says above.
  
 
-## Additional files
+## 📄 Additional files
 
 To develop the frontend you will need a file called `dot.credentials.ts`. This can contain personal information so is never pushed to git. You can bypass this by creating a file with the same name and adding the following contents:
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ _Have an idea for our website? You can drop a suggestion in our [Discord server]
     The site is now running and you can visit in your browser of choice *(hopefully [Dot Browser](https://github.com/dothq/browser))* at `localhost:8000/`. If the port is different in the above message, you can substitute `:8000` for what it says above.
  
 
+## Additional files
+
+To develop the frontend you will need a file called `dot.credentials.ts`. This can contain personal information so is never pushed to git. You can bypass this by creating a file with the same name and adding the following contents:
+
+```ts
+export default {}
+```
+
 ## 🎓 Learning Gatsby
 
 Looking for more guidance? Full documentation for Gatsby lives [on the website](https://www.gatsbyjs.org/). Here are some places to start:

--- a/src/components/Ending/index.tsx
+++ b/src/components/Ending/index.tsx
@@ -11,7 +11,7 @@ const Ending = () => (
             <Container>
                 <Title>Ready for some privacy?</Title>
                 <div style={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
-                    <Link to={"/download"}>
+                    <Link to={"https://github.com/dothq/browser-pr-builds/releases"}>
                         <ButtonV2 background={"white"} color={"black"} w={173}>Download</ButtonV2>
                     </Link>
                 </div>

--- a/src/components/Features/index.tsx
+++ b/src/components/Features/index.tsx
@@ -38,6 +38,8 @@ export const Features = () => {
 
     return (
         <>
+            <div id="features-section"></div>
+
             <div id="features" dot-slideup="true" style={{ animationDelay: '1.8s', paddingTop: '3rem' }}>
                 <FeatureDisplay>
                     <Feature>

--- a/src/pages/browser/download/index.tsx
+++ b/src/pages/browser/download/index.tsx
@@ -79,7 +79,9 @@ class DotBrowserPage extends React.Component {
                                 <HeroTitle color={"white"}>Browse securely without prying eyes</HeroTitle>
                                 <HeroSubtitle color={"white"}>Get Dot Browser to block annoying advertisments and trackers. It’s that simple.</HeroSubtitle>
                                 <Buttons className={"db-download-buttons"} style={{ marginTop: '72px', display: 'flex', justifyContent: 'flex-start' }}>
-                                    <ButtonV2 background={"white"} color={"black"}>Download for {getOS() && getOS().os}</ButtonV2>
+                                    <Link to={"https://github.com/dothq/browser-pr-builds/releases"}>
+                                        <ButtonV2 background={"white"} color={"black"}>Download for {getOS() && getOS().os}</ButtonV2>
+                                    </Link>
                                     <Link to={"/browser/download/mobile"}>
                                         <ButtonV2 background={"transparent"} color={"white"}>Try our mobile version</ButtonV2>
                                     </Link>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,11 +22,11 @@ const IndexPage = () => {
           
           <div dot-slideup="true" style={{ animationDelay: '0.8s' }}>
             <Buttons style={{ marginBottom: '34px' }} className={"landing-btns"}>
-              <Link to={"/#features"}>
+              <Link to={"/browser/download"}>
                 <ButtonV2 background={"#f6f6f6"} color={"black"}>Learn More</ButtonV2>
               </Link>
-              <Link to={"/#"} style={{ marginLeft: '12px' }}>
-                <ButtonV2>Download Coming Soon</ButtonV2>
+              <Link to={"https://github.com/dothq/browser-pr-builds/releases"} style={{ marginLeft: '12px' }}>
+                <ButtonV2>Download Alpha</ButtonV2>
               </Link>
             </Buttons>
           </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,7 +22,7 @@ const IndexPage = () => {
           
           <div dot-slideup="true" style={{ animationDelay: '0.8s' }}>
             <Buttons style={{ marginBottom: '34px' }} className={"landing-btns"}>
-              <Link to={"/browser/download"}>
+              <Link to={"#features-section"}>
                 <ButtonV2 background={"#f6f6f6"} color={"black"}>Learn More</ButtonV2>
               </Link>
               <Link to={"https://github.com/dothq/browser-pr-builds/releases"} style={{ marginLeft: '12px' }}>


### PR DESCRIPTION
## Links

### Learn more link was broken on screen sizes less than 1080p
On larger screen sizes the learn more link jumps down to the features section. On smaller screens this doesn't currently happen.

https://user-images.githubusercontent.com/23250792/102845136-fac9a400-4460-11eb-9162-d1beca49d30f.mov

Fixed:

https://user-images.githubusercontent.com/23250792/102845146-ff8e5800-4460-11eb-9c09-759493e5d2b7.mov


### Download links
I have set download links to redirect to the [builds page](https://github.com/dothq/browser-pr-builds/releases). If you didn't intend for these buttons to work this way, I can change it back.

## Documentation

In the readme it states that you have to run `yarn develop` rather than `yarn develop:web` or `yarn develop:api`. It also makes no mention of `dot.credentials.ts` and how to work around the need for it to exist for the development environment to run. Both of these issues are fixed in this pull request.
